### PR TITLE
Fix TaskCommandLineEventArgs not getting ignored properly

### DIFF
--- a/TeamCity.MSBuild.Logger/EventHandlers/MessageHandler.cs
+++ b/TeamCity.MSBuild.Logger/EventHandlers/MessageHandler.cs
@@ -39,7 +39,7 @@
             var lightenText = false;
             if (e is TaskCommandLineEventArgs)
             {
-                if (_context.Parameters.ShowCommandLine.HasValue && !_context.Parameters.ShowCommandLine.Value && !_context.IsVerbosityAtLeast(LoggerVerbosity.Normal))
+                if (_context.Parameters.ShowCommandLine.HasValue && !_context.Parameters.ShowCommandLine.Value || !_context.Parameters.ShowCommandLine.HasValue && !_context.IsVerbosityAtLeast(LoggerVerbosity.Normal))
                 {
                     return;
                 }


### PR DESCRIPTION
Fixes #12 

I noticed when using this msbuild logger that all of my csc.exe messages were bleeding through even though the Verbosity was minimal.

So I looked into the consolelogger implementation for msbuild and spotted the culprit:
https://github.com/dotnet/msbuild/blob/5c3e613314e4d5fcef0b90be3fe931db2e5a6128/src/Build/Logging/ParallelLogger/ParallelConsoleLogger.cs#L1061-L1067

Could be related to #10 but I'm not sure.